### PR TITLE
fix: correct mirror window position and size on extended monitors

### DIFF
--- a/pin-agent/Pin/Sources/Core/AgentStateMachine.swift
+++ b/pin-agent/Pin/Sources/Core/AgentStateMachine.swift
@@ -94,10 +94,13 @@ final class AgentStateMachine {
         }
         mirrorController.onGeometryChange = { [weak self] newSize in
             guard let self = self else { return }
+            // Use the screen where the mirror window is displayed, not NSScreen.main
+            // This ensures correct scaling when moving between Retina and non-Retina screens
+            let screen = self.mirrorWindowController?.currentScreen
             self.windowCaptureManager?.updateStreamSize(
                 newWidth: newSize.width,
                 newHeight: newSize.height,
-                screen: NSScreen.main
+                screen: screen
             )
         }
         mirrorController.onUnpin = { [weak self] in


### PR DESCRIPTION
- Fix coordinate conversion to use primary screen (menu bar screen) instead of NSScreen.main for Quartz to Cocoa conversion
- Add support for secondary screen with different origin.y offset
- Fix Retina scaling when moving windows between displays with different backingScaleFactor (2.0 vs 1.0)
- Set videoGravity and contentsScale on AVSampleBufferDisplayLayer
- Use actual window screen for capture size updates instead of NSScreen.main