### PR TITLE
docs: Update Pin for Raycast description in README

### DIFF
--- a/pin-raycast/README.md
+++ b/pin-raycast/README.md
@@ -1,6 +1,6 @@
 # Pin for Raycast
 
-A Raycast extension for controlling [Pin.app](https://github.com/southflowpeak/Pin) from Raycast.
+A simple Raycast extension for pinning any window to stay always on top via [Pin](https://southflowpeak.com/pin).
 
 ## About Pin.app
 


### PR DESCRIPTION
Update the Pin for Raycast extension description to be more concise and align with Pin.app's official website link.