### PR TITLE
chore: Use {PR_MERGE_DATE} placeholder in CHANGELOG

### DIFF
--- a/pin-raycast/CHANGELOG.md
+++ b/pin-raycast/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Pin Changelog
 
-## [Initial Version] - 2026-01-24
+## [Initial Version] - {PR_MERGE_DATE}
 
 - Control Pin.app via Raycast


### PR DESCRIPTION
Replace hardcoded date with {PR_MERGE_DATE} placeholder in the CHANGELOG. This allows the date to be automatically filled in when the PR is merged.